### PR TITLE
Fixed Sidebar Navigation Issue

### DIFF
--- a/fantasystock/frontend/src/containers/Navigation/Navigation.jsx
+++ b/fantasystock/frontend/src/containers/Navigation/Navigation.jsx
@@ -40,7 +40,7 @@ function Navigation(props) {
             design="VerticalNavbarIcons1"
           />
           <ClickableIcons
-            to="/stocks"
+            to="/league"
             icon={faFootball}
             name="League"
             design="VerticalNavbarIcons1"


### PR DESCRIPTION
Fixed Issue #31. Clicking the Football Icon in the sidebar now redirects to the "league" page regardless of the sidebar being expanded or not.