### PR TITLE
In progress Issue #60

### DIFF
--- a/fantasystock/backend/utils/updateLeagues.js
+++ b/fantasystock/backend/utils/updateLeagues.js
@@ -5,9 +5,11 @@ const user = require("../models/user");
 
 module.exports = async () => {
   const right_now = new Date();
+  console.log(right_now); // outputs in UTC format
+  console.log(right_now.toLocaleDateString()); // outputs in our actual timezone just month/day/year
 
   const updatable_leagues = await League.find({
-    start: { $lte: right_now },
+    start: { $lte: right_now.toLocaleDateString() },
     active: true,
   });
 


### PR DESCRIPTION
The problem is that when a user creates a league and selects for example 11/20/22 for the start date and 11/21/22 for the end date, it gets stored in UTC format. The UTC format for today's date 11/17/22 is 2022-11-18T06:19:54.661Z (notice that the day changes from 17 to 18). We were comparing that UTC start date with the current UTC date, which explains leagues being passed earlier than supposed to. If instead we compare the stored UTC start date with the actual current date not in UTC format, it should work properly. Still needs testing to ensure, but I'm pretty sure this fixes the problem.