### PR TITLE
Updated 'join' in leagues.js

### DIFF
--- a/fantasystock/backend/routes/leagues.js
+++ b/fantasystock/backend/routes/leagues.js
@@ -163,9 +163,17 @@ router.patch("/join", jsonParser, async (req, res) => {
 
   // can not join a league that has already passed
   const rightnow = new Date();
+  //console.log(rightnow);
+  //console.log(rightnow.toLocaleDateString());
   const game = await League.findById(req.body.gameID);
-  if (rightnow > game.end) {
-    console.log("Can not join a league that has expired.");
+  //console.log(game.start);
+  const game_year = game.start.getFullYear();
+  const game_month = game.start.getMonth() + 1;
+  const game_day = game.start.getDate() + 1;
+  const game_full = [game_month, game_day, game_year].join('/');
+  //console.log(game_full);
+  if (rightnow.toLocaleDateString() >= game_full) {  // current datetime must be less than the gamestart datetime in order to join a league
+    console.log("Can not join a league that has already started.");
     res.send({ created: false });
     return;
   }
@@ -229,7 +237,6 @@ router.patch("/join", jsonParser, async (req, res) => {
     }
   }
 
-
   // if all data validation passed, then proceed to join the league
   const exists = League.exists({ _id: req.body.gameID });
 
@@ -259,6 +266,7 @@ router.patch("/join", jsonParser, async (req, res) => {
       console.log(e);
     }
 
+    console.log("Joined league successfully");
     game.save();
     res.send({ success: true });
   }


### PR DESCRIPTION
A user can now only join a league if the current date(month/day/year) is less than the league start date(month/day/year). In other words if the current date is 11/20/2022 and the league start date is 11/20/2022, user won't be able to join. If the current date is 11/20/2022 and the league start date is 11/19/2022, user won't be able to join. If the current date is 11/20/2022 and the league start date is 11/21/2022, user will be able to join. They must join at least 1 day in advance, can not join the same day the league starts.